### PR TITLE
Signature generation should not rely on the default encoding

### DIFF
--- a/src/com/amazon/pay/api/SignatureHelper.java
+++ b/src/com/amazon/pay/api/SignatureHelper.java
@@ -20,6 +20,7 @@ import org.bouncycastle.util.encoders.Base64;
 import org.bouncycastle.util.encoders.Hex;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
@@ -125,7 +126,7 @@ public class SignatureHelper {
                 ServiceConstants.MASK_GENERATION_FUNCTION, mgf1ParameterSpec, SALT_LENGTH, TRAILER_FIELD);
         signature.setParameter(pssParameterSpec);
         signature.initSign(privateKey);
-        signature.update(stringToSign.getBytes());
+        signature.update(stringToSign.getBytes(StandardCharsets.UTF_8));
 
         return new String(Base64.encode(signature.sign()));
     }
@@ -321,7 +322,7 @@ public class SignatureHelper {
      */
     private String hashThenHexEncode(final String requestPayload) throws NoSuchAlgorithmException {
         final MessageDigest md = MessageDigest.getInstance(ServiceConstants.HASH_ALGORITHM);
-        md.update(requestPayload.getBytes());
+        md.update(requestPayload.getBytes(StandardCharsets.UTF_8));
         final byte[] digest = md.digest();
 
         final String contentSha256 = new String((Hex.encode(digest)));


### PR DESCRIPTION
*Description of changes:*

`AmazonPayClient#generateButtonSignature()` could return incorrect signature when the payload contains non-ascii characters and the system's default encoding is not UTF-8.
I encountered this issue when I set some Japanese characters in `noteToBuyer`.

Although setting `file.encoding` property can be a workaround, it should not be required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
