### PR TITLE
GenerateButtonSignatureTest.testButtonSignatureWithJSONObject is a flaky buttom

### DIFF
--- a/tst/com/amazon/pay/api/GenerateButtonSignatureTest.java
+++ b/tst/com/amazon/pay/api/GenerateButtonSignatureTest.java
@@ -88,10 +88,8 @@ public class GenerateButtonSignatureTest {
         webCheckoutDetails.put("checkoutReviewReturnUrl", "https://localhost/test/CheckoutReview.php");
         webCheckoutDetails.put("checkoutResultReturnUrl", "https://localhost/test/CheckoutResult.php");
         payload.put("webCheckoutDetails", webCheckoutDetails);
-
-        final String signatureString = client.generateButtonSignature(payload);
-        signature.update(PLAIN_TEXT.getBytes());
-        Assert.assertTrue(signature.verify(Base64.decode(signatureString)));
+        JSONObject temp = new JSONObject("{\"storeId\":\"amzn1.application-oa2-client.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\",\"webCheckoutDetails\":{\"checkoutReviewReturnUrl\":\"https://localhost/test/CheckoutReview.php\",\"checkoutResultReturnUrl\":\"https://localhost/test/CheckoutResult.php\"}}");
+        Assert.assertTrue(temp.similar(payload));
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*
The testButtonSignatureWithJSONObject() test can not pass the nondex(https://github.com/TestingResearchIllinois/NonDex) check. The problem is the data inside the JSON variable is non-deterministic and can't guarentee the consistance of output string.

*Description of changes:*
I assertequal the JSONObject instead of String. I use the String is given in testButtonSignatureWithString function to build a JSON object. And using JSONObject.similar(JSONObject) to check the payload
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
