### PR TITLE
Fix flaky test UtilTest.testEnhanceResponseWithShippingAddressList

### DIFF
--- a/tst/com/amazon/pay/api/UtilTest.java
+++ b/tst/com/amazon/pay/api/UtilTest.java
@@ -254,7 +254,9 @@ public class UtilTest {
         expectedCheckoutSessionResponse.setResponse(expectedShippingAddressListResponse);
         expectedCheckoutSessionResponse.setRawResponse(expectedShippingAddressListResponse.toString());
 
-        Assert.assertEquals(expectedCheckoutSessionResponse.getRawResponse(), actualCheckoutSessionResponseAfterEnhancing.getRawResponse());
+        JSONObject expected = new JSONObject(expectedCheckoutSessionResponse.getRawResponse());
+        JSONObject actual = new JSONObject(actualCheckoutSessionResponseAfterEnhancing.getRawResponse());
+        Assert.assertTrue(expected.similar(actual));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*

This PR aims to fix a test:
```
com.amazon.pay.api.UtilTest.testEnhanceResponseWithShippingAddressList
```

This was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

**REASON AND FIX**

Encountered the following error while using NonDex:
```
com.amazon.pay.api.UtilTest.testEnhanceResponseWithShippingAddressList -- Time elapsed: 0.002 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<...pingAddressList":[{"[city":null,"addressId":"amzn1.address.ABC","phoneNumber":"8910111213","postalCode":"123-4567","stateOrRegion":"MNO","county":null,"addressLine3":null,"name":"DEF","district":null,"countryCode":"JP","addressLine2":"JKL","addressLine1":"GHI"]}]}> but was:<...pingAddressList":[{"[postalCode":"123-4567","county":null,"addressId":"amzn1.address.ABC","phoneNumber":"8910111213","countryCode":"JP","addressLine3":null,"addressLine1":"GHI","addressLine2":"JKL","name":"DEF","stateOrRegion":"MNO","city":null,"district":null]}]}>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at com.amazon.pay.api.UtilTest.testEnhanceResponseWithShippingAddressList(UtilTest.java:257)

```
The tests fails when the function `testEnhanceResponseWithShippingAddressList()` compares both strings (*expectedCheckoutSessionResponse.RawResponse and actualCheckoutSessionResponseAfterEnhancing.RawResponse*) with key-value pairs in it. 

The JSON object is unordered since it uses Maps as their internal data structure. According to [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html),

*"This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time."*

Due to this a non-deterministic order of key-value pairs are maintained and hence the assertEquals fails.

https://github.com/amzn/amazon-pay-api-sdk-java/blob/3ff564edb9509ca63ed7e8f77df9b42f3261f287/tst/com/amazon/pay/api/UtilTest.java#L257

One possible solution is to have those strings as JSONObjects and compare  using [JSONObject.similar()](https://stleary.github.io/JSON-java/org/json/JSONObject.html#method.summary), which compares if the contents of two JSON objects are same, perhaps having a different order of attributes.


**Reproduce:**

This was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

The following command can be used to replicate the failures and validate the fix:

```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.amazon.pay.api.UtilTest#testEnhanceResponseWithShippingAddressList
```

**Environment:**

> Java: openjdk version "11.0.20.1"
> Maven: Apache Maven 3.6.3

No user-facing change.
No dependency upgrade.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
